### PR TITLE
setup: setup wrapper for llm and embedding

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,10 +9,33 @@ QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", None)
 
 
 # LLM Provider
-LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")  # Use openai or vllm
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
+EMBEDDER_PROVIDER = os.getenv("EMBEDDER_PROVIDER", "openai")
+
+if LLM_PROVIDER not in ["openai", "ollama", "vllm"]:
+    raise ValueError("LLM_PROVIDER must be one of 'openai', 'ollama', or 'vllm'.")
+
+if EMBEDDER_PROVIDER not in ["openai", "ollama"]:
+    raise ValueError("EMBEDDER_PROVIDER must be one of 'openai' or 'ollama'")
+
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", None)
 
 if LLM_PROVIDER == "openai" and not OPENAI_API_KEY:
     raise ValueError(
         "OPENAI_API_KEY must be set when using OpenAI as the LLM provider."
     )
+
+MODEL_NAME = os.getenv("MODEL_NAME", None)
+
+if not MODEL_NAME:
+    raise ValueError("MODEL_NAME must be set.")
+
+if EMBEDDER_PROVIDER == "openai" and not OPENAI_API_KEY:
+    raise ValueError(
+        "OPENAI_API_KEY must be set when using OpenAI as the embedder provider."
+    )
+
+EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL_NAME", None)
+
+if not EMBEDDING_MODEL_NAME:
+    raise ValueError("EMBEDDING_MODEL_NAME must be set.")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,1 @@
+from .provider import *

--- a/app/models/provider.py
+++ b/app/models/provider.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class Provider(Enum):
+    """
+    Enum for different LLM provider types.
+    """
+
+    OPENAI = "openai"
+    OLLAMA = "ollama"
+    VLLM = "vllm"
+
+
+class EmbedProvider(Enum):
+    """
+    Enum for different embedding provider types.
+    """
+
+    OPENAI = "openai"
+    OLLAMA = "ollama"

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,2 @@
+from .embed import Embedder
+from .llm import LLM

--- a/app/services/embed.py
+++ b/app/services/embed.py
@@ -1,0 +1,76 @@
+from typing import Optional, Union
+from langchain_core.embeddings import Embeddings
+from langchain_ollama import OllamaEmbeddings
+from langchain_openai import OpenAIEmbeddings
+from ..models import EmbedProvider
+from ..config import LLM_PROVIDER, OPENAI_API_KEY, MODEL_NAME
+
+
+class Embedder:
+    """
+    Embedder class to handle embedding operations using different providers.
+    This class is a wrapper around LangChain's embedding clients for OpenAI and Ollama.
+    """
+
+    def __init__(
+        self,
+        provider: Union[EmbedProvider, str] = EmbedProvider(LLM_PROVIDER),
+        api_key: Optional[str] = OPENAI_API_KEY,
+        **kwargs,
+    ):
+        """
+        Initializes the Embedder with the specified provider and API key.
+
+        Args:
+            provider (EmbedProvider, optional): Provider to the embedding model. Defaults to EmbedProvider(LLM_PROVIDER).
+            api_key (Optional[str], optional): api key to the embedding model provider. If using local provider, no api key is needed. Defaults to OPENAI_API_KEY.
+            kwargs: Additional keyword arguments to pass to the embedding client.
+
+        Raises:
+            ValueError: If the provider is not supported.
+        """
+        if isinstance(provider, str):
+            try:
+                provider = EmbedProvider(provider)
+            except ValueError:
+                raise ValueError(f"Unsupported embedding provider: {provider}")
+
+        self.provider = provider
+        self.client: Optional[Embeddings] = None
+
+        if provider == EmbedProvider.OPENAI:
+            self.client = OpenAIEmbeddings(
+                model="text-embedding-3-large",
+                api_key=api_key,
+                **kwargs,
+            )
+        elif provider == EmbedProvider.OLLAMA:
+            self.client = OllamaEmbeddings(
+                model=MODEL_NAME,
+                **kwargs,
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {provider}")
+
+    def get_vector_size(self) -> int:
+        """
+        Returns the size of the embedding vector.
+
+        This method retrieves a sample embedding and returns its length, which represents the size of the embedding vector.
+
+        Returns:
+            int: The size of the embedding vector.
+        """
+        sample_embedding = self.client.embed_query(text="Dit Me Duy")
+        return len(sample_embedding)
+
+    def get_client(self) -> Embeddings:
+        """
+        Returns the embedding client.
+
+        This method provides access to the embedding client instance, which can be used to perform embedding operations.
+
+        Returns:
+            Embeddings: The embedding client instance.
+        """
+        return self.client

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,0 +1,68 @@
+from typing import Optional, Union
+from langchain_ollama import ChatOllama
+from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
+from ..config import LLM_PROVIDER, OPENAI_API_KEY, MODEL_NAME
+from ..models import Provider
+
+
+class LLM:
+    """
+    A service class for interacting with different LLM providers.
+    This is a wrapper around LangChain's chat models to provide a unified interface
+    for different LLM providers like OpenAI, Ollama, and VLLM.
+    """
+
+    def __init__(
+        self,
+        provider: Union[Provider, str] = Provider(LLM_PROVIDER),
+        model: str = MODEL_NAME,
+        api_key: Optional[str] = OPENAI_API_KEY,
+        **kwargs,
+    ):
+        """
+        Initializes the LLM service with the specified provider, model, and API key.
+
+        Args:
+            provider (Provider, optional): LLM Provider. Defaults to LLM_PROVIDER.
+            model (str, optional): The name of the model to use. Defaults to MODEL_NAME.
+            api_key (Optional[str], optional): The api key of the provider, if use local providers, no api key is needed. Defaults to OPENAI_API_KEY.
+            kwargs: Additional keyword arguments to pass to the chat model client.
+
+        Raises:
+            NotImplementedError: If the provider is vllm, which is not implemented yet.
+            ValueError: If the provider is not supported.
+        """
+        if isinstance(provider, str):
+            try:
+                provider = Provider(provider)
+            except ValueError:
+                raise ValueError(f"Unsupported provider: {provider}")
+
+        self.provider = provider
+        self.client: Optional[BaseChatModel] = None
+
+        if provider == Provider.OPENAI:
+            self.client = ChatOpenAI(
+                model=model,
+                api_key=api_key,
+                **kwargs,
+            )
+        elif provider == Provider.OLLAMA:
+            self.client = ChatOllama(
+                model=model,
+                **kwargs,
+            )
+        elif provider == Provider.VLLM:
+            raise NotImplementedError("vllm provider is not implemented yet.")
+        else:
+            raise ValueError(f"Unsupported provider: {provider}")
+
+    def get_client(self) -> BaseChatModel:
+        """
+        Returns the chat model client.
+
+        Returns:
+            BaseChatModel: The chat model client instance.
+        """
+        return self.client

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ tiktoken
 boto3
 langchain-community
 langchain
+langchain-openai
+langchain-ollama
 python-dotenv
 unstructured
 unstructured[pdf]

--- a/test/embed.py
+++ b/test/embed.py
@@ -1,0 +1,10 @@
+from app.services import Embedder
+
+if __name__ == "__main__":
+    embedder = Embedder()
+
+    try:
+        print(embedder.get_vector_size())
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        print("Make sure model is downloaded and ollama is running if using Ollama.")

--- a/test/llm.py
+++ b/test/llm.py
@@ -1,0 +1,39 @@
+from langchain import hub
+from langchain.tools import tool
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompts import PromptTemplate
+from app.services import LLM
+
+
+@tool
+def get_temperature() -> str:
+    """Get the current temperature."""
+    return "The current temperature is 20 degrees Celsius."
+
+
+@tool
+def get_date() -> str:
+    """Get the current date."""
+    return "Today's date is 2023-10-01."
+
+
+if __name__ == "__main__":
+    llm = LLM(provider="openai", model="gpt-4.1-2025-04-14")
+    client = llm.get_client()
+    tools = [get_temperature, get_date]
+
+    try:
+        prompt = hub.pull("hwchase17/react")
+
+        agent = create_react_agent(client, tools, prompt)
+
+        agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+
+        agent_executor.invoke({"input": "what is your name?"})
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        # print(
+        #     f"Make sure to run ollama server, and make sure model is downloaded if using Ollama."
+        # )


### PR DESCRIPTION
# Setup: Wrapper for LLM and Embedding
This PR added wrappers around the LLM chat model (currently support openai and ollama) and Embeddings (also support openai and ollama). The main component added is llm.py and embed.py under app/services folder

# Description
The wrappers are designed to:
- Load the chat model depending on the provider (openai or local providers like ollama)
- Offer easy switching between providers by changing the environment setting
- Offer quick access and interaction with the underlying chat model client through the `get_client()` function.

# Key Features
- Modular design: New providers can easily be added to the wrapper as long as those providers **inherit** the `BaseChatModel` from Langchain (which already integrated with a lot of providers)
- Test-Friendly: 2 tests: `llm.py` and `embed.py` are added to the /test directory for experimentation, prototyping and validation.
- Easy switching between providers: If you want to switch to other providers, you can easily switch by changing the environment.
- Additional custom arguments can be added to the wrapper to be passed to the client to change the behavior of the underlying client.

# Use Cases
- Serve as the building block for the question-answering graph or agent.
- Easy prototype and testing providers.

# Example Usage:
```
    llm = LLM(provider="openai", model="gpt-4.1-2025-04-14")
    client = llm.get_client()
    # invoke, ainvoke, stream, astream, etc with client instance
```

```
    embedder = Embedder()
    print(embedder.get_vector_size()) # Get the size of the embedding vector
    client = embedder.get_client() # Get underlying client
    client.embed_query() # Use as any Embedding object
```